### PR TITLE
filter out posthog auto properties and events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,12 +53,14 @@ export const exportEvents: AvoInspectorPlugin['exportEvents'] = async (events, {
     }
 
     for (const event of events) {
-        avoEvents.push({
-            ...baseEventPayload,
-            eventName: event.event,
-            messageId: event.uuid,
-            eventProperties: event.properties ? convertPosthogPropsToAvoProps(event.properties) : [],
-        })
+        if (!event.event.startsWith("$")) {
+            avoEvents.push({
+                ...baseEventPayload,
+                eventName: event.event,
+                messageId: event.uuid,
+                eventProperties: event.properties ? convertPosthogPropsToAvoProps(event.properties) : [],
+            })
+        }
     }
 
     try {
@@ -116,7 +118,9 @@ export const exportEvents: AvoInspectorPlugin['exportEvents'] = async (events, {
 const convertPosthogPropsToAvoProps = (properties: Record<string, any>): Record<string, string>[] => {
     const avoProps = []
     for (const [propertyName, propertyValue] of Object.entries(properties)) {
-        avoProps.push({ propertyName, propertyType: getPropValueType(propertyValue) })
+        if (!propertyName.startsWith("$")) {
+            avoProps.push({ propertyName, propertyType: getPropValueType(propertyValue) })
+        };
     }
     return avoProps
 }


### PR DESCRIPTION
Filter out events and properties that start with $, to remove automatically tracked event and properties by Posthog, so the inspector is not reporting on these properties that are not in the tracking plan.

Question is then later HMW count for events/properties that the clients do want to track in their tracking plan and are part of Posthog's automatic events/properties? 


Not sure how I test this as a posthog plugin @yakkomajuri ? Currently untested