### PR TITLE
Move to onEvent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,7 @@ export const onEvent: AvoInspectorPlugin['onEvent'] = async (event, { config, gl
         const trackEventsRes = await fetch('https://api.avo.app/inspector/posthog/v1/track', {
             method: 'POST',
             headers: global.defaultHeaders,
-            body: JSON.stringify(avoEvent),
+            body: JSON.stringify([avoEvent]),
         })
 
         // https://github.com/node-fetch/node-fetch/issues/1262


### PR DESCRIPTION
We're deprecating exportEvents and it's special buffering to either batch exports or onEvent function.

Based on logs this is how much we currently batch (PostHog US cloud across everyone for some hours, noting in EU cloud), the >1 occurrences would be sent one event at a time after this PR:

<img width="297" alt="Screenshot 2023-09-19 at 19 50 35" src="https://github.com/PostHog/posthog-avo-plugin/assets/890921/692bfd95-859a-4eac-821e-0625bc40d9ba">

