### PR TITLE
feat: Support include/exclude properties

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ export const setupPlugin: AvoInspectorPlugin['setupPlugin'] = async ({ config, g
     )
 }
 
-export const composeWebhook: AvoInspectorPlugin['onEvent'] = async (event, { config, global }) => {
+export const composeWebhook: AvoInspectorPlugin['onEvent'] = (event, { config, global }) => {
     const isIncluded = global.includeEvents.length > 0 ? global.includeEvents.includes(event.event) : true
     const isExcluded = global.excludeEvents.includes(event.event)
 

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ interface AvoInspectorMeta {
         environment: string
         excludeEvents: string[]
         includeEvents: string[]
-        excludeProerties: string[]
+        excludeProperties: string[]
         includeProperties: string[]
     }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { Plugin } from '@posthog/plugin-scaffold'
 
 interface AvoInspectorMeta {

--- a/index.ts
+++ b/index.ts
@@ -43,8 +43,8 @@ export const setupPlugin: AvoInspectorPlugin['setupPlugin'] = async ({ config, g
 }
 
 export const composeWebhook: AvoInspectorPlugin['onEvent'] = (event, { config, global }) => {
-    const isIncluded = global.includeEvents.length > 0 ? global.includeEvents.includes(event.event) : true
-    const isExcluded = global.excludeEvents.includes(event.event)
+    const isIncluded = global.includeEvents.length > 0 ? global.includeEvents.has(event.event) : true
+    const isExcluded = global.excludeEvents.has(event.event)
 
     if (event.event.startsWith("$") || (isExcluded || !isIncluded)) {
         return

--- a/index.ts
+++ b/index.ts
@@ -50,12 +50,14 @@ export const composeWebhook: AvoInspectorPlugin['onEvent'] = (event, { config, g
         return
     }
 
+    const sessionId = randomUUID()
     const now = new Date().toISOString()
 
     const baseEventPayload = {
         apiKey: config.avoApiKey,
         env: config.environment,
         appName: config.appName,
+        sessionId: sessionId,
         createdAt: now,
         avoFunction: false,
         eventId: null,

--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,10 @@ interface AvoInspectorMeta {
         appName: string
         avoApiKey: string
         environment: string
+        excludeEvents: string[]
+        includeEvents: string[]
         excludeProerties: string[]
-        inlucdeProperties: string[]
+        includeProperties: string[]
     }
 }
 type AvoInspectorPlugin = Plugin<AvoInspectorMeta>
@@ -26,7 +28,10 @@ export const setupPlugin: AvoInspectorPlugin['setupPlugin'] = async ({ config, g
 }
 
 export const onEvent: AvoInspectorPlugin['onEvent'] = async (event, { config, global }) => {
-    if (event.event.startsWith("$")) {
+    const isIncluded = config.includeEvents.length > 0 ? config.includeEvents.includes(event.event) : true
+    const isExcluded = config.excludeEvents.includes(event.event)
+
+    if (event.event.startsWith("$") && isIncluded && !isExcluded) {
         return
     }
 

--- a/index.ts
+++ b/index.ts
@@ -66,32 +66,6 @@ export const onEvent: AvoInspectorPlugin['onEvent'] = async (event, { config, gl
     }
 
     try {
-        // start a tracking session
-        const sessionStartRes = await fetch('https://api.avo.app/inspector/posthog/v1/track', {
-            method: 'POST',
-            headers: global.defaultHeaders,
-            body: JSON.stringify([
-                {
-                    apiKey: config.avoApiKey,
-                    env: config.environment,
-                    appName: config.appName,
-                    createdAt: now,
-                    sessionId: sessionId,
-                    appVersion: '1.0.0',
-                    libVersion: '1.0.1',
-                    libPlatform: 'node',
-                    messageId: randomUUID(),
-                    trackingId: '',
-                    samplingRate: 1,
-                    type: 'sessionStarted',
-                },
-            ]),
-        })
-
-        if (sessionStartRes.status !== 200) {
-            throw new Error(`sessionStarted request failed with status code ${sessionStartRes.status}`)
-        }
-
         // track events
         const trackEventsRes = await fetch('https://api.avo.app/inspector/posthog/v1/track', {
             method: 'POST',

--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,7 @@ export const composeWebhook: AvoInspectorPlugin['onEvent'] = (event, { config, g
     const isIncluded = global.includeEvents.length > 0 ? global.includeEvents.includes(event.event) : true
     const isExcluded = global.excludeEvents.includes(event.event)
 
-    if (event.event.startsWith("$") && isIncluded && !isExcluded) {
+    if (event.event.startsWith("$") || (isExcluded || !isIncluded)) {
         return
     }
 

--- a/index.ts
+++ b/index.ts
@@ -95,9 +95,11 @@ const convertPosthogPropsToAvoProps = (properties: Record<string, any>, excludeP
         const isIncluded = includeProperties.size > 0 ? includeProperties.has(propertyName) : true
         const isExcluded = excludeProperties.has(propertyName)
 
-        if (!propertyName.startsWith("$") && isIncluded && !isExcluded) {
-            avoProps.push({ propertyName, propertyType: getPropValueType(propertyValue) })
-        };
+        if (propertyName.startsWith("$") || (isExcluded || !isIncluded)) {
+            continue;
+        }
+
+        avoProps.push({ propertyName, propertyType: getPropValueType(propertyValue) });
     }
     return avoProps
 }


### PR DESCRIPTION
Users may need to control which properties we send to Avo as the schemas are checked on their side. For this reason, let's support two new configuration keys:
* `excludeProperties`: An array of string which can be set to property names to exclude from the event sent to Avo. By default, nothing is excluded.
* `includeProperties`: An array of string which can be set to property names to include in the event sent to Avo (and effectively exclude everything else). By default, everything is included.

