### PR TITLE
chore: Update plugin json with new configuration values

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,6 +28,38 @@
             "type": "string",
             "default": "PostHog",
             "required": false
+        },
+        {
+            "key": "excludeEvents",
+            "hint": "Comma-separated list of events that will not be sent to Avo.",
+            "name": "Events to exclude",
+            "type": "string",
+            "default": "",
+            "required": false
+        },
+        {
+            "key": "includeEvents",
+            "hint": "Comma-separated list of events to send to Avo. All others will be ignored.",
+            "name": "Events to include",
+            "type": "string",
+            "default": "",
+            "required": false
+        },
+        {
+            "key": "excludeProperties",
+            "hint": "Comma-separated list of event properties that will not be sent to Avo.",
+            "name": "Properties to exclude",
+            "type": "string",
+            "default": "",
+            "required": false
+        },
+        {
+            "key": "includeProperties",
+            "hint": "Comma-separated list of event properties to send to Avo. All other properties will not be sent.",
+            "name": "Properties to include",
+            "type": "string",
+            "default": "",
+            "required": false
         }
     ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -39,7 +39,7 @@
         },
         {
             "key": "includeEvents",
-            "hint": "Comma-separated list of events to send to Avo. All others will be ignored.",
+            "hint": "Comma separated list of events to send to Avo (will send all if left empty).",
             "name": "Events to include",
             "type": "string",
             "default": "",
@@ -55,7 +55,7 @@
         },
         {
             "key": "includeProperties",
-            "hint": "Comma-separated list of event properties to send to Avo. All other properties will not be sent.",
+            "hint": "Comma separated list of event properties to send to Avo (will send all if left empty).",
             "name": "Properties to include",
             "type": "string",
             "default": "",


### PR DESCRIPTION
My last PR #3  added new configuration keys but didn't update the `plugin.json` file. This could mean properties cannot be used.